### PR TITLE
feature/fix: rake db seed hook

### DIFF
--- a/lib/apartment/tasks/enhancements.rb
+++ b/lib/apartment/tasks/enhancements.rb
@@ -6,7 +6,7 @@ module Apartment
 
     module TASKS
       ENHANCE_BEFORE = %w(db:drop)
-      ENHANCE_AFTER  = %w(db:migrate db:rollback db:migrate:up db:migrate:down db:migrate:redo db:seed)
+      ENHANCE_AFTER  = %w(db:migrate db:rollback db:migrate:up db:migrate:down db:migrate:redo)
       freeze
     end
 


### PR DESCRIPTION
Hooking `rake db:seed` conflicts with `seed_after_create = true` configuration value.